### PR TITLE
Harden and enhance Kloak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,30 @@
 #!/usr/bin/make -f
 
+TARGETARCH=$(shell gcc -dumpmachine)
+
+# https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
+# Omitted the following flags:
+# -D_GLIBCXX_ASSERTIONS  # application is not written in C++
+# -fstrict-flex-arrays=3 # not supported in Debian Bookworm's GCC version (12)
+# -fPIC -shared          # not a shared library
+# -fexceptions           # not multithreaded
+# -fhardened             # not supported in Debian Bookworm's GCC version (12)
+CFLAGS = -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
+  -Werror=format-security -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
+	-fstack-clash-protection \
+	-fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro \
+	-Wl,-z,now -Wl,--as-needed -Wl,--no-copy-dt-needed-entries -Wtrampolines \
+	-Wbidi-chars=any -fPIE -pie -Werror=implicit \
+	-Werror=incompatible-pointer-types -Werror=int-conversion \
+	-fno-delete-null-pointer-checks -fno-strict-overflow -fno-strict-aliasing
+
+ifeq ($(TARGETARCH), x86_64-linux-gnu)
+	CFLAGS += -fcf-protection=full # only supported on x86_64
+endif
+ifeq ($(TARGETARCH), aarch64-linux-gnu)
+  CFLAGS += -mbranch-protection=standard # only supported on aarch64
+endif
+
 all : kloak eventcap
 
 kloak : src/main.c src/keycodes.c src/keycodes.h

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,16 @@
 TARGETARCH=$(shell gcc -dumpmachine)
 
 # https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
+#
 # Omitted the following flags:
 # -D_GLIBCXX_ASSERTIONS  # application is not written in C++
 # -fstrict-flex-arrays=3 # not supported in Debian Bookworm's GCC version (12)
 # -fPIC -shared          # not a shared library
 # -fexceptions           # not multithreaded
 # -fhardened             # not supported in Debian Bookworm's GCC version (12)
+#
+# Added the following flags:
+# -fsanitize=address,undefined # enable ASan/UBSan
 CFLAGS = -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
   -Werror=format-security -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
 	-fstack-clash-protection \
@@ -16,7 +20,8 @@ CFLAGS = -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
 	-Wl,-z,now -Wl,--as-needed -Wl,--no-copy-dt-needed-entries -Wtrampolines \
 	-Wbidi-chars=any -fPIE -pie -Werror=implicit \
 	-Werror=incompatible-pointer-types -Werror=int-conversion \
-	-fno-delete-null-pointer-checks -fno-strict-overflow -fno-strict-aliasing
+	-fno-delete-null-pointer-checks -fno-strict-overflow -fno-strict-aliasing \
+	-fsanitize=address,undefined
 
 ifeq ($(TARGETARCH), x86_64-linux-gnu)
 	CFLAGS += -fcf-protection=full # only supported on x86_64

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Source: kloak
 Section: misc
 Priority: optional
 Maintainer: Patrick Schleizer <adrelanos@whonix.org>
-Build-Depends: debhelper (>= 13.11.6), debhelper-compat (= 13), dh-apparmor, libevdev2, libevdev-dev, libsodium23, libsodium-dev, pkg-config
+Build-Depends: debhelper (>= 13.11.4), debhelper-compat (= 13), dh-apparmor, libevdev2, libevdev-dev, libsodium23, libsodium-dev, pkg-config
 Homepage: https://github.com/vmonaco/kloak
 Vcs-Browser: https://github.com/vmonaco/kloak
 Vcs-Git: https://github.com/vmonaco/kloak.git

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Package: kloak
 ## qemu:handle_cpu_signal received signal outside vCPU context @ pc=0x60269d8c
 ## qemu:handle_cpu_signal received signal outside vCPU context @ pc=0x6000178c
 ## Update: Same as above.
-Architecture: amd64
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libevdev2, libsodium23
 Description: anti keystroke deanonymization tool
  A keystroke-level online anonymization kernel.

--- a/debian/kloak.install
+++ b/debian/kloak.install
@@ -8,3 +8,4 @@ kloak usr/sbin/
 
 etc/*
 usr/*
+lib/*

--- a/lib/udev/rules.d/95-kloak.rules
+++ b/lib/udev/rules.d/95-kloak.rules
@@ -1,0 +1,23 @@
+SUBSYSTEM!="input", GOTO="end"
+
+
+# do not run kloak on devices created by kloak
+KERNEL=="event*", ATTRS{name}=="kloak*", GOTO="end"
+
+# new keyboard or mouse attached, start kloak@event[0-9].service
+KERNEL=="event*", ACTION=="add", ENV{ID_INPUT_KEYBOARD}=="1", RUN+="/usr/bin/systemctl restart kloak.service"
+KERNEL=="event*", ACTION=="add", ENV{ID_INPUT_KEYBOARD}=="1", GOTO="end"
+
+KERNEL=="event*", ACTION=="add", ENV{ID_INPUT_MOUSE}=="1", RUN+="/usr/bin/systemctl restart kloak.service"
+KERNEL=="event*", ACTION=="add", ENV{ID_INPUT_MOUSE}=="1", GOTO="end"
+
+
+# keyboard or mouse removed, stop the service
+KERNEL=="event*", ACTION=="remove", ENV{ID_INPUT_KEYBOARD}=="1", RUN+="/usr/bin/systemctl restart kloak.service"
+KERNEL=="event*", ACTION=="remove", ENV{ID_INPUT_KEYBOARD}=="1", GOTO="end"
+
+KERNEL=="event*", ACTION=="remove", ENV{ID_INPUT_MOUSE}=="1", RUN+="/usr/bin/systemctl restart kloak.service"
+KERNEL=="event*", ACTION=="remove", ENV{ID_INPUT_MOUSE}=="1", GOTO="end"
+
+
+LABEL="end"

--- a/src/kloak.h
+++ b/src/kloak.h
@@ -1,0 +1,28 @@
+#ifndef KLOAK_H
+#define KLOAK_H
+
+struct entry {
+        struct input_event iev;
+        long time;
+        TAILQ_ENTRY(entry) entries;
+        int device_index;
+};
+
+ssize_t strtcpy(char *, const char *, size_t);
+void sleep_ms(long int);
+long current_time_ms(void);
+long int random_between(long int, long int);
+void set_rescue_keys(const char*);
+int supports_event_type(int, int);
+int supports_specific_key(int, unsigned int);
+int is_keyboard(int);
+int is_mouse(int);
+void detect_devices();
+void init_inputs();
+void init_outputs();
+void emit_event(struct entry *);
+void main_loop();
+void usage();
+void banner();
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -16,8 +16,8 @@
 #include "keycodes.h"
 
 #define BUFSIZE 256                  // for device names and rescue key sequence
-#define MAX_INPUTS 16                // number of devices to try autodetection
-#define MAX_DEVICES 16               // max number of devices to read events from
+#define MAX_INPUTS 48                // number of devices to try autodetection
+#define MAX_DEVICES 48               // max number of devices to read events from
 #define MAX_RESCUE_KEYS 10           // max number of rescue keys to exit in case of emergency
 #define MIN_KEYBOARD_KEYS 20         // need at least this many keys to be a keyboard
 #define POLL_TIMEOUT_MS 1            // timeout to check for new events

--- a/src/main.c
+++ b/src/main.c
@@ -232,11 +232,14 @@ void init_inputs() {
 }
 
 void init_outputs() {
+    const char *name = "kloak output device";
     for (int i = 0; i < device_count; i++) {
         int err = libevdev_new_from_fd(input_fds[i], &output_devs[i]);
 
         if (err != 0)
             panic("Could not create evdev for input device: %s", named_inputs[i]);
+
+        libevdev_set_name(output_devs[i], name);
 
         err = libevdev_uinput_create_from_device(output_devs[i], LIBEVDEV_UINPUT_OPEN_MANAGED, &uidevs[i]);
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include <libevdev/libevdev.h>
 #include <libevdev/libevdev-uinput.h>
 
+#include "kloak.h"
 #include "keycodes.h"
 
 #define BUFSIZE 256                  // for device names and rescue key sequence
@@ -62,13 +63,6 @@ static struct option long_options[] = {
 };
 
 TAILQ_HEAD(tailhead, entry) head;
-
-struct entry {
-    struct input_event iev;
-    long time;
-    TAILQ_ENTRY(entry) entries;
-    int device_index;
-};
 
 // From string_copying manpage
 ssize_t strtcpy(char *restrict dst, const char *restrict src, size_t dsize)

--- a/src/main.c
+++ b/src/main.c
@@ -192,7 +192,7 @@ void detect_devices() {
     char device[BUFSIZE];
 
     for (int i = 0; i < MAX_DEVICES; i++) {
-        sprintf(device, "/dev/input/event%d", i);
+        snprintf(device, sizeof(device), "/dev/input/event%d", i);
 
         if ((fd = open(device, O_RDONLY)) < 0) {
             continue;

--- a/src/main.c
+++ b/src/main.c
@@ -89,7 +89,8 @@ void sleep_ms(long milliseconds) {
     struct timespec ts;
     ts.tv_sec = milliseconds / 1000;
     ts.tv_nsec = (milliseconds % 1000) * 1000000;
-    nanosleep(&ts, NULL);
+    if (nanosleep(&ts, NULL) == -1)
+      panic("nanosleep failed: %s", strerror(errno));
 }
 
 long current_time_ms(void) {
@@ -141,7 +142,8 @@ void set_rescue_keys(const char* rescue_keys_str) {
 int supports_event_type(int device_fd, int event_type) {
     unsigned long evbit = 0;
     // Get the bit field of available event types.
-    ioctl(device_fd, EVIOCGBIT(0, sizeof(evbit)), &evbit);
+    if (ioctl(device_fd, EVIOCGBIT(0, sizeof(evbit)), &evbit) == -1)
+      panic("ioctl EVIOCGBIT failed: %s", strerror(errno));
     // NOTE: EVIOCGBIT ioctl returns an int, see handle_eviocgbit function in
     // linux/drivers/input/evdev.c, thus this cast is safe
     return (int)evbit & (1 << event_type);
@@ -151,7 +153,8 @@ int supports_specific_key(int device_fd, unsigned int key) {
     size_t nchar = KEY_MAX/8 + 1;
     unsigned char bits[nchar];
     // Get the bit fields of available keys.
-    ioctl(device_fd, EVIOCGBIT(EV_KEY, sizeof(bits)), &bits);
+    if (ioctl(device_fd, EVIOCGBIT(EV_KEY, sizeof(bits)), &bits) == -1)
+      panic("ioctl EVIOCGBIT for EV_KEY failed: %s", strerror(errno));
     return bits[key/8] & (1 << (key % 8));
 }
 
@@ -197,7 +200,8 @@ void detect_devices() {
                 printf("Found mouse at: %s\n", device);
         }
 
-        close(fd);
+        if (close(fd) == -1)
+          panic("close failed on device: %s, error: %s", device, strerror(errno));
 
         if (device_count >= MAX_INPUTS) {
             if (verbose)
@@ -418,7 +422,7 @@ int main(int argc, char **argv) {
         case 'r':
             if (device_count >= MAX_INPUTS)
                 panic("Too many -r options: can read from at most %d devices\n", MAX_INPUTS);
-            strncpy(named_inputs[device_count++], optarg, BUFSIZE-1);
+            strtcpy(named_inputs[device_count++], optarg, BUFSIZE);
             break;
 
         case 'd':
@@ -432,7 +436,7 @@ int main(int argc, char **argv) {
             break;
 
         case 'k':
-            strncpy(rescue_keys_str, optarg, BUFSIZE-1);
+            strtcpy(rescue_keys_str, optarg, BUFSIZE);
             break;
 
         case 'v':

--- a/src/main.c
+++ b/src/main.c
@@ -77,7 +77,7 @@ void sleep_ms(long milliseconds) {
 
 long current_time_ms(void) {
     struct timespec spec;
-    clock_gettime(CLOCK_REALTIME, &spec);
+    clock_gettime(CLOCK_MONOTONIC, &spec);
     return (spec.tv_sec) * 1000 + (spec.tv_nsec) / 1000000;
 }
 

--- a/usr/lib/systemd/system/kloak.service
+++ b/usr/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom newfstatat clock_nanosleep pselect6 poll shmctl openat getdents64
+SystemCallFilter=brk clock_nanosleep close execve faccessat getdents64 getpid getrandom getuid ioctl madvise mmap mprotect munmap newfstatat openat ppoll prlimit64 read readlinkat rseq rt_sigaction set_robust_list set_tid_address sigaltstack write rt_sigprocmask sysinfo uname getcwd
 
 [Install]
 WantedBy=multi-user.target

--- a/usr/lib/systemd/system/kloak.service
+++ b/usr/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=brk clock_nanosleep close execve faccessat getdents64 getpid getrandom getuid ioctl madvise mmap mprotect munmap newfstatat openat ppoll prlimit64 read readlinkat rseq rt_sigaction set_robust_list set_tid_address sigaltstack write rt_sigprocmask sysinfo uname getcwd
+SystemCallFilter=brk clock_nanosleep close execve faccessat getdents64 getpid getrandom getuid ioctl madvise mmap mprotect munmap newfstatat openat ppoll prlimit64 read readlinkat rseq rt_sigaction set_robust_list set_tid_address sigaltstack write rt_sigprocmask sysinfo uname getcwd access fstat pread64 poll
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Changes

* Enabled a battery of compile-time hardening flags, following the recommendations from https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html and fixed code issues revealed by additional warnings
* Added changes from https://github.com/vmonaco/kloak/pull/61 (add a header file to make future development easier)
* Added some changes from https://github.com/vmonaco/kloak/pull/65 (ChatGPT-recommended code fixes, some of these I took a different approach to enhancing, in particular the strncpy fixes)
* Added functionality from https://github.com/vmonaco/kloak/pull/67 (add support for new devices attached after kloak starts)
* Enabled use of ASan and UBSan
* Replaced most `strncpy` uses with `strtcpy` recommended by https://man7.org/linux/man-pages/man7/string_copying.7.html
* Resolved issues with ARM support (syscall filtering, disabled builds on all architectures but amd64)
* Resolved issue with keyboard "jamming" when the clock goes backwards (https://forums.whonix.org/t/sdwdate-can-cause-system-time-to-jump-backwards-causing-issue-with-kloak/20433)
* Increased the number of supported simultaneous input devices to cope with systems that have many input devices attached at once (like my development laptop)
* Caused resources to be cleaned up when `panic` is called (based on advice from a "ChatGPT-4o mini" code review)

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.whonix.org/wiki/Terms_of_Service), [Privacy Policy](https://www.whonix.org/wiki/Privacy_Policy), [Cookie Policy](https://www.whonix.org/wiki/Cookie_Policy), [E-Sign Consent](https://www.whonix.org/wiki/E-Sign_Consent), [DMCA](https://www.whonix.org/wiki/DMCA), [Imprint](https://www.whonix.org/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it (testing was done manually and may have to be in the future, I did NOT add an automated test suite)

Fixes https://github.com/vmonaco/kloak/issues/31, https://github.com/vmonaco/kloak/issues/25, https://github.com/vmonaco/kloak/issues/35

## Potential Issues

I have attempted to make the syscall filter work properly, however it is only tested on my particular x86_64 and arm64 machines. It is entirely possible it will crash on other people's machines. In the event this happens, one can find out which syscall triggered the crash by running `journalctl -n50`, scrolling to the bottom, and looking for the last instance of the word `syscall` in the journal log fragment. This should pull up a kernel audit or seccomp audit line, containing a value similar to `syscall=21`. This is the number of the not-yet-whitelisted syscall that crashed the process. Find out which syscall that number corresponds to (look in `/usr/include/ARCH-linux=gnu/asm/unistd.h` to figure out which file contains the syscall table, then go to whatever that file happens to be, replace `ARCH` as appropriate for your system's architecture), then add that syscall name to the `SystemCallFilter` entry in `kloak/usr/lib/systemd/system/kloak.service` . Copy the file into place, `systemctl daemon-reload`, and `systemctl restart kloak`. This should either get kloak up and running, or result in another error pointing out a different syscall that isn't whitelisted yet.