### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install dependencies:
 
 Fedora:
 
-    $ sudo dnf install make pkgconf-pkg-config libsodium libsodium-devel libevdev libevdev-devel
+    $ sudo dnf install gcc libevdev-devel libsodium-devel libubsan make pkgconf-pkg-config
 
 Debian:
 


### PR DESCRIPTION
Update dependencies information for Fedora, specifically adding gcc and libubsan(required for newer versions, there is no devel package available for it). And removing libevdev and libsodium(both are required by their respective devel packages, so their explicit listing here is unnecessary).

This pull request changes...

## Changes

## Mandatory Checklist

- [ x ] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.whonix.org/wiki/Terms_of_Service), [Privacy Policy](https://www.whonix.org/wiki/Privacy_Policy), [Cookie Policy](https://www.whonix.org/wiki/Cookie_Policy), [E-Sign Consent](https://www.whonix.org/wiki/E-Sign_Consent), [DMCA](https://www.whonix.org/wiki/DMCA), [Imprint](https://www.whonix.org/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ x ] I have tested it locally
- [ x ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
