### PR TITLE
A slightly more sophisticated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,26 @@
 #!/usr/bin/make -f
 
-TARGETARCH=$(shell gcc -dumpmachine)
+CC         ?= gcc
+INSTALL    ?= install
+PKG_CONFIG ?= pkg-config
+RONN       ?= ronn
+
+CFLAGS     ?= -O2 -g
+
+# NOTE: The systemd unit and apparmor profile are hardcoded to use
+#       /usr/sbin/kloak. So if you change the default install paths,
+#       you will have to patch those files yourself.
+prefix         ?= /usr
+sbindir        ?= $(prefix)/sbin
+datadir        ?= $(prefix)/share
+mandir         ?= $(datadir)/man
+
+udev_rules_dir ?= /lib/udev/rules.d
+apparmor_dir   ?= /etc/apparmor.d/
+systemd_dir    ?= /usr/lib/systemd/system
+
+TARGETARCH=$(shell $(CC) -dumpmachine)
+CC_VERSION=$(shell $(CC) --version)
 
 # https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
 #
@@ -13,34 +33,57 @@ TARGETARCH=$(shell gcc -dumpmachine)
 #
 # Added the following flags:
 # -fsanitize=address,undefined # enable ASan/UBSan
-CFLAGS = -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
-  -Werror=format-security -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
-	-fstack-clash-protection \
-	-fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro \
-	-Wl,-z,now -Wl,--as-needed -Wl,--no-copy-dt-needed-entries -Wtrampolines \
-	-Wbidi-chars=any -fPIE -pie -Werror=implicit \
-	-Werror=incompatible-pointer-types -Werror=int-conversion \
-	-fno-delete-null-pointer-checks -fno-strict-overflow -fno-strict-aliasing \
-	-fsanitize=undefined
+WARN_CFLAGS := -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
+	-Werror=format-security -Werror=implicit -Werror=int-conversion \
+	-Werror=incompatible-pointer-types
 
-ifeq ($(TARGETARCH), x86_64-linux-gnu)
-CFLAGS += -fcf-protection=full # only supported on x86_64
-endif
-ifeq ($(TARGETARCH), aarch64-linux-gnu)
-CFLAGS += -mbranch-protection=standard # only supported on aarch64
+ifeq (,$(findstring clang,$(CC_VERSION))) # if not clang
+WARN_CFLAGS += -Wtrampolines -Wbidi-chars=any  # clang as for 18.1.8 doesn't support this warnings
 endif
 
-ifeq (, $(shell which pkg-config))
+FORTIFY_CFLAGS := -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstack-clash-protection \
+	-fstack-protector-strong -fno-delete-null-pointer-checks \
+	-fno-strict-overflow -fno-strict-aliasing -fsanitize=undefined
+
+ifeq (yes,$(patsubst x86_64%-linux-gnu,yes,$(TARGETARCH)))
+FORTIFY_CFLAGS += -fcf-protection=full # only supported on x86_64
+endif
+ifeq (yes,$(patsubst aarch64%-linux-gnu,yes,$(TARGETARCH)))
+FORTIFY_CFLAGS += -mbranch-protection=standard # only supported on aarch64
+endif
+
+BIN_CFLAGS := -fPIE
+
+CFLAGS := $(WARN_CFLAGS) $(FORTIFY_CFLAGS) $(BIN_CFLAGS) $(CFLAGS)
+LDFLAGS := -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now \
+	-Wl,--as-needed -Wl,--no-copy-dt-needed-entries -pie $(LDFLAGS)
+
+ifeq (, $(shell which $(PKG_CONFIG)))
 $(error pkg-config not installed!)
 endif
 
 all : kloak eventcap
 
 kloak : src/main.c src/keycodes.c src/keycodes.h
-	gcc -g src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+	$(CC) src/main.c src/keycodes.c -o kloak -lm $(shell $(PKG_CONFIG) --cflags --libs libevdev) $(shell $(PKG_CONFIG) --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 eventcap : src/eventcap.c
-	gcc -g src/eventcap.c -o eventcap $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+	$(CC) src/eventcap.c -o eventcap $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+
+MANPAGES := auto-generated-man-pages/eventcap.8 auto-generated-man-pages/kloak.8
+
+man : $(MANPAGES)
+
+auto-generated-man-pages/% : man/%.ronn
+	ronn --manual="kloak Manual" --organization="kloak" <$< >$@
 
 clean :
 	rm -f kloak eventcap
+
+install : all lib/udev/rules.d/95-kloak.rules etc/apparmor.d/usr.sbin.kloak  usr/lib/systemd/system/kloak.service $(MANPAGES)
+	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR), $(sbindir) $(mandir)/man8 $(udev_rules_dir) $(apparmor_dir) $(systemd_dir))
+	$(INSTALL) -m 755 kloak eventcap $(DESTDIR)$(sbindir)
+	$(INSTALL) -m 644 $(MANPAGES) $(DESTDIR)$(mandir)/man8
+	$(INSTALL) -m 644 lib/udev/rules.d/95-kloak.rules $(DESTDIR)$(udev_rules_dir)
+	$(INSTALL) -m 644 etc/apparmor.d/usr.sbin.kloak $(DESTDIR)$(apparmor_dir)
+	$(INSTALL) -m 644 usr/lib/systemd/system/kloak.service $(DESTDIR)$(systemd_dir)


### PR DESCRIPTION
- support for override of the compiler and utils
- support for append/override CFLAGS
- a target to update man pages
- install target
- better handling of conditional flags, particularly:
  - disable some warnings on non-gcc compilers
  - handle GNU's tuples like `x86-64-pc-linux-gnu` and `aarch-unknowv-linux-gnu`
- organize CFLAGS by sorting them into categories

This pull request changes...

## Changes

## Mandatory Checklist

- [X] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.whonix.org/wiki/Terms_of_Service), [Privacy Policy](https://www.whonix.org/wiki/Privacy_Policy), [Cookie Policy](https://www.whonix.org/wiki/Cookie_Policy), [E-Sign Consent](https://www.whonix.org/wiki/E-Sign_Consent), [DMCA](https://www.whonix.org/wiki/DMCA), [Imprint](https://www.whonix.org/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
