### PR TITLE
Fix runtime failure due to width=0 without right/left anchors

### DIFF
--- a/src/kloak.c
+++ b/src/kloak.c
@@ -1688,14 +1688,13 @@ static struct drawable_layer *allocate_drawable_layer(struct disp_state *param_s
     zwlr_layer_surface_v1_add_listener(layer->layer_surface,
       &layer_surface_listener, param_state);
 
-    zwlr_layer_surface_v1_set_anchor(layer->layer_surface,
-      ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP);
-    zwlr_layer_surface_v1_set_anchor(layer->layer_surface,
-      ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM);
-    zwlr_layer_surface_v1_set_anchor(layer->layer_surface,
-      ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT);
-    zwlr_layer_surface_v1_set_anchor(layer->layer_surface,
-      ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+    zwlr_layer_surface_v1_set_anchor(
+      layer->layer_surface,
+      ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+      ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+      ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
+      ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT
+    );
     zwlr_layer_surface_v1_set_exclusive_zone(layer->layer_surface, -1);
     wl_surface_commit(layer->surface);
   }


### PR DESCRIPTION
## Changes

This pull request ensures kloak does not fail in wlroots environments with https://github.com/swaywm/wlroots/commit/8dec751a6d84335fb04288b8efab6dd5c90288d3.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.whonix.org/wiki/Terms_of_Service), [Privacy Policy](https://www.whonix.org/wiki/Privacy_Policy), [Cookie Policy](https://www.whonix.org/wiki/Cookie_Policy), [E-Sign Consent](https://www.whonix.org/wiki/E-Sign_Consent), [DMCA](https://www.whonix.org/wiki/DMCA), [Imprint](https://www.whonix.org/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #13 
