### PR TITLE
Add retry logic for inotify watch initialization with exponential backoff

### DIFF
--- a/src/kloak.c
+++ b/src/kloak.c
@@ -2704,6 +2704,9 @@ static void applayer_libinput_init(void) {
 }
 
 static void applayer_inotify_init(void) {
+  int retry = 0;
+  int64_t delay_ms = INOTIFY_WATCH_INITIAL_DELAY_MS;
+
   inotify_fd = inotify_init1(IN_CLOEXEC);
   if (inotify_fd == -1) {
     fprintf(stderr, "FATAL ERROR: Could not initialize inotify: %s\n",
@@ -2711,12 +2714,31 @@ static void applayer_inotify_init(void) {
     exit(1);
   }
 
-  if (inotify_add_watch(inotify_fd, "/dev/input", IN_CREATE | IN_DELETE)
-    == -1) {
+  for (retry = 0; retry <= INOTIFY_WATCH_MAX_RETRIES; retry++) {
+    if (inotify_add_watch(inotify_fd, "/dev/input", IN_CREATE | IN_DELETE)
+      != -1) {
+      return;
+    }
+
+    if (errno != ENOSPC || retry == INOTIFY_WATCH_MAX_RETRIES) {
+      fprintf(stderr,
+        "FATAL ERROR: Could not add inotify watch on /dev/input: %s\n",
+        strerror(errno));
+      if (errno == ENOSPC) {
+        fprintf(stderr,
+          "The system limit for inotify watches has been reached.\n"
+          "Consider increasing the limit by running:\n"
+          "  sysctl fs.inotify.max_user_watches=65536\n");
+      }
+      exit(1);
+    }
+
     fprintf(stderr,
-      "FATAL ERROR: Could not add inotify watch on /dev/input: %s\n",
-      strerror(errno));
-    exit(1);
+      "WARNING: inotify watch limit reached (ENOSPC), "
+      "retrying in %d ms (attempt %d/%d)...\n",
+      (int)(delay_ms), retry + 1, INOTIFY_WATCH_MAX_RETRIES);
+    sleep_ms(delay_ms);
+    delay_ms *= 2;
   }
 }
 

--- a/src/kloak.h
+++ b/src/kloak.h
@@ -31,6 +31,8 @@
 #define MAX_UNRELEASED_FRAMES 3
 #define POLL_FD_COUNT 3
 #define INOTIFY_READ_BUF_LEN 16384
+#define INOTIFY_WATCH_MAX_RETRIES 5
+#define INOTIFY_WATCH_INITIAL_DELAY_MS 1000
 
 #ifndef min
 #define min(a, b) ( ((a) < (b)) ? (a) : (b) )
@@ -599,7 +601,8 @@ static void applayer_wayland_init(void);
 static void applayer_libinput_init(void);
 
 /*
- * Watches /dev/input for device creation and deletion.
+ * Watches /dev/input for device creation and deletion. Retries with
+ * exponential backoff if the system inotify watch limit is reached (ENOSPC).
  */
 static void applayer_inotify_init(void);
 

--- a/usr/lib/systemd/system/kloak.service
+++ b/usr/lib/systemd/system/kloak.service
@@ -8,6 +8,8 @@ Documentation=man:kloak(8)
 ConditionPathExists=!/run/qubes/this-is-templatevm
 After=graphical.target
 After=sysmaint-boot.target
+StartLimitBurst=5
+StartLimitIntervalSec=30s
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary
This PR adds resilience to inotify watch initialization by implementing retry logic with exponential backoff when the system inotify watch limit is reached. This prevents kloak from failing immediately when the system is under high inotify load.

## Key Changes
- **Retry mechanism**: Added a retry loop (up to 5 attempts) in `applayer_inotify_init()` when `inotify_add_watch()` fails with `ENOSPC` (no space/limit reached)
- **Exponential backoff**: Implemented exponential backoff starting at 1000ms, doubling with each retry attempt
- **Improved error messaging**: Enhanced error output to distinguish between transient `ENOSPC` errors and permanent failures, with helpful guidance on increasing system limits
- **Systemd service hardening**: Added `StartLimitBurst=5` and `StartLimitIntervalSec=30s` to the systemd service file to allow the service to restart during the retry window
- **Constants**: Added `INOTIFY_WATCH_MAX_RETRIES` (5) and `INOTIFY_WATCH_INITIAL_DELAY_MS` (1000) configuration constants
- **Documentation**: Updated function comment to reflect the new retry behavior

## Implementation Details
- The retry loop only retries on `ENOSPC` errors; other errors still cause immediate failure
- When `ENOSPC` is encountered, a warning is logged with the current attempt number and total retries
- The exponential backoff strategy gives the system time to free up inotify watches between attempts
- The systemd service configuration ensures the service can restart multiple times within a 30-second window if needed

https://claude.ai/code/session_01Rv6naXAk9nKjkGFeJ1e9EB